### PR TITLE
Improve arena visuals and movement

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -136,12 +136,14 @@ function draw() {
   ctx.scale(cam.zoom, cam.zoom);
   ctx.translate(-cam.x, -cam.y);
 
-  ctx.fillStyle = theme === "dark" ? "#1f2937" : "#e5e7eb";
+  // Plain black or white world background instead of gray
+  ctx.fillStyle = theme === "dark" ? "#000000" : "#ffffff";
   ctx.fillRect(-worldSize, -worldSize, worldSize * 2, worldSize * 2);
 
-  ctx.fillStyle = theme === "dark" ? "#94a3b8" : "#94a3b8";
+  // Render each food pellet using its own color
   for (const f of state.foods) {
     ctx.beginPath();
+    ctx.fillStyle = f.color;
     ctx.arc(f.x, f.y, 3, 0, Math.PI * 2);
     ctx.fill();
   }


### PR DESCRIPTION
## Summary
- Randomize pellet colors and transmit to clients
- Replace gray board with black/white and render pellets with their colors
- Use mass-based speed formula and increase overall food count

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js >/tmp/start.log & sleep 1; cat /tmp/start.log; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68b575cb6f4083298dd635d04f1bbc6a