### PR TITLE
Add ejection, splitting and viruses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
## Summary
- Improve movement speed and introduce ejected mass, splitting dash and virus interactions
- Render grid and virus objects client-side with keyboard controls for split and eject
- Ignore node_modules in version control

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68b578e0511483299c30efdba2e4f00e